### PR TITLE
Feature/#11 create error handling

### DIFF
--- a/WeatherApp-MVVM/Models/APICaller.swift
+++ b/WeatherApp-MVVM/Models/APICaller.swift
@@ -15,23 +15,23 @@ import CoreLocation
 protocol WeatherAPIProtcol {
     func fetchWeatherData<req: WeatherRequest>(request: req) -> Single<req.ResponseType>
     func fetchWeatherIcon(iconName: String) -> Single<Data?>
-    func setupRequest(prefecture: String) -> WeatherRequestModel
-    func setupRequest(location: CLLocation) -> WeatherRequestModel
+    func setupRequest<R: WeatherRequest>(prefecture: String, model: R) -> R
+    func setupRequest<R: WeatherRequest>(location: CLLocation, model: R) -> R
 }
 
 class APICaller: WeatherAPIProtcol {
     
-    func setupRequest(prefecture: String) -> WeatherRequestModel {
-        var request = WeatherRequestModel()
-        request.parameters["q"] = prefecture
-        return request
+    func setupRequest<R: WeatherRequest>(prefecture: String, model: R) -> R {
+        var model = model
+        model.parameters["q"] = prefecture
+        return model
     }
     
-    func setupRequest(location: CLLocation) -> WeatherRequestModel {
-        var request = WeatherRequestModel()
-        request.parameters["lat"] = String(location.coordinate.latitude)
-        request.parameters["lon"] = String(location.coordinate.longitude)
-        return request
+    func setupRequest<R: WeatherRequest>(location: CLLocation, model: R) -> R {
+        var model = model
+        model.parameters["lat"] = String(location.coordinate.latitude)
+        model.parameters["lon"] = String(location.coordinate.longitude)
+        return model
     }
     
     func fetchWeatherData<req: WeatherRequest>(request: req) -> Single<req.ResponseType> {

--- a/WeatherApp-MVVM/Models/APICaller.swift
+++ b/WeatherApp-MVVM/Models/APICaller.swift
@@ -48,7 +48,7 @@ class APICaller: WeatherAPIProtcol {
                     if let weather = response.value {
                         single(.success(weather))
                     } else {
-                        single(.failure(ResponseError.nilData))
+                        single(.failure(APIError.nilData))
                     }
                 case .failure(let error):
                     single(.failure(error))
@@ -73,6 +73,3 @@ class APICaller: WeatherAPIProtcol {
     }
 }
 
-enum ResponseError: Error {
-    case nilData
-}

--- a/WeatherApp-MVVM/Models/APICaller.swift
+++ b/WeatherApp-MVVM/Models/APICaller.swift
@@ -14,7 +14,7 @@ import CoreLocation
 
 protocol WeatherAPIProtcol {
     func fetchWeatherData<req: WeatherRequest>(request: req) -> Single<req.ResponseType>
-    func fetchWeatherIcon(iconName: String) -> Single<Data>
+    func fetchWeatherIcon(iconName: String) -> Single<Data?>
     func setupRequest(prefecture: String) -> WeatherRequestModel
     func setupRequest(location: CLLocation) -> WeatherRequestModel
 }
@@ -56,15 +56,11 @@ class APICaller: WeatherAPIProtcol {
         }
     }
     
-    func fetchWeatherIcon(iconName: String) -> Single<Data>{
+    func fetchWeatherIcon(iconName: String) -> Single<Data?>{
         return Single.create { single in
             let iconUrl = "https://openweathermap.org/img/wn/\(iconName).png"
             let request = AF.request(iconUrl).response { response in
-                if let data = response.data {
-                    single(.success(data))
-                } else {
-                    single(.failure(NSError(domain: "", code: -1, userInfo: nil)))  // Error handling here
-                }
+                single(.success(response.data))
             }
             return Disposables.create {
                 request.cancel()

--- a/WeatherApp-MVVM/Models/APICaller.swift
+++ b/WeatherApp-MVVM/Models/APICaller.swift
@@ -38,7 +38,11 @@ class APICaller: WeatherAPIProtcol {
         return Single<req.ResponseType>.create { single in
             let decoder = JSONDecoder()
             // AF.requestでタイムアウト8秒、statusCode200番以外は.responseValidationFailedエラーで返すを設定
-            let weatherRequest = AF.request(request.baseURL + request.path, parameters: request.parameters, requestModifier: { $0.timeoutInterval = 8.0 }).validate(statusCode:  200..<300).responseDecodable(of: req.ResponseType.self, decoder: decoder) { response in
+            let weatherRequest = AF.request(request.baseURL + request.path,
+                                            parameters: request.parameters,
+                                            requestModifier: { $0.timeoutInterval = 8.0 })
+                .validate(statusCode:  200..<300)
+                .responseDecodable(of: req.ResponseType.self, decoder: decoder) { response in
                 switch response.result {
                 case .success:
                     if let weather = response.value {

--- a/WeatherApp-MVVM/Models/WeatherRecuest.swift
+++ b/WeatherApp-MVVM/Models/WeatherRecuest.swift
@@ -33,3 +33,19 @@ struct WeatherRequestModel: WeatherRequest {
         return (["appid": apikey, "cnt": count, "units": unit, "lang": lang])
     }()
 }
+
+
+struct ErrorRequestModel: WeatherRequest {
+    typealias ResponseType = WeatherData
+
+    var path = "/data/2.5/forecast?"
+    var parameters: Parameters = {
+        let apikey = "error"
+        let count = "8"
+        let unit = "metric"
+        let lang = "ja"
+        return (["appid": apikey, "cnt": count, "units": unit, "lang": lang])
+    }()
+    
+    
+}

--- a/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
+++ b/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
@@ -192,7 +192,7 @@ class DetailViewModel {
         
         return weatherModel.fetchWeatherIcon(iconName: iconName) // Single<Data>で返ってくる
             .map { iconData in
-                DisplayWeatherData(date: date, time: time, iconData: iconData, maxTemparture: maxTemparture, minTemparture: minTemparture, humidity: humidit)
+                DisplayWeatherData(date: date, time: time, iconData: iconData ?? Data(), maxTemparture: maxTemparture, minTemparture: minTemparture, humidity: humidit)
             }
     }
     

--- a/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
+++ b/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
@@ -101,10 +101,10 @@ class DetailViewModel {
                                 case .timedOut:
                                     self.APIErrorMessage.accept("タイムアウトしました")
                                 default :
-                                    print("URLError　Other Error: \(urlError.localizedDescription)")
+                                    self.APIErrorMessage.accept("URLError　Other Error: \(urlError.localizedDescription)")
                                 }
                             } else {
-                                print("SessionTaskFailed　Other Error: \(sessionError)")
+                                self.APIErrorMessage.accept("SessionTaskFailed　Other Error: \(sessionError)")
                             }
 
                             // status codeが200番台以外を検知
@@ -115,7 +115,7 @@ class DetailViewModel {
                                     self.APIErrorMessage.accept("データの取得に失敗しました")
                                 }
                             default :
-                                print("Response Validation Other Error")
+                                self.APIErrorMessage.accept("Response Validation Other Error")
                             }
                             
                             // レスポンスエラー(主にデコードエラーを検知)
@@ -124,10 +124,10 @@ class DetailViewModel {
                             case .decodingFailed:
                                 self.APIErrorMessage.accept("デコードに失敗しました")
                             default:
-                                print("Response Other Error")
+                                self.APIErrorMessage.accept("Response Other Error")
                             }
                         default :
-                            print("Other AFError: \(afError)")
+                            self.APIErrorMessage.accept("Other AFError: \(afError)")
                         }
                     }
                     else if let responceError = error as? ResponseError {
@@ -137,7 +137,7 @@ class DetailViewModel {
                         }
                     }
                     else {
-                        print("Other Error: \(error)")
+                        self.APIErrorMessage.accept("Other Error: \(error)")
                     }
                 })
                 .disposed(by: disposeBag)

--- a/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
+++ b/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
@@ -62,10 +62,10 @@ class DetailViewModel {
             // prefectureが渡されているか、初期化時にlocationが渡されているかで条件分岐
             let weatherDataSingle: Single<WeatherData>
             if let prefecture = prefecture {
-                let request = weatherModel.setupRequest(prefecture: prefecture)
+                let request = weatherModel.setupRequest(prefecture: prefecture, model: WeatherRequestModel())
                 weatherDataSingle = self.weatherModel.fetchWeatherData(request: request)
             } else if let location = location {
-                let request = weatherModel.setupRequest(location: location)
+                let request = weatherModel.setupRequest(location: location, model: WeatherRequestModel())
                 weatherDataSingle = self.weatherModel.fetchWeatherData(request: request)
             } else {
                 weatherDataSingle = Single.error(ParameterError.parameterUnSet("現在地も都道府県もセットされていません"))

--- a/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
+++ b/WeatherApp-MVVM/ViewModels/DetailViewModel.swift
@@ -101,10 +101,10 @@ class DetailViewModel {
                                 case .timedOut:
                                     self.APIErrorMessage.accept("タイムアウトしました")
                                 default :
-                                    print("SessionError　Other Error")
+                                    print("URLError　Other Error: \(urlError.localizedDescription)")
                                 }
                             } else {
-                                print("SessionTaskFailed　Other Error")
+                                print("SessionTaskFailed　Other Error: \(sessionError)")
                             }
 
                             // status codeが200番台以外を検知
@@ -124,10 +124,10 @@ class DetailViewModel {
                             case .decodingFailed:
                                 self.APIErrorMessage.accept("デコードに失敗しました")
                             default:
-                                print("Response Other Error: \(error)")
+                                print("Response Other Error")
                             }
                         default :
-                            print("Other Error: \(error)")
+                            print("Other AFError: \(afError)")
                         }
                     }
                     else if let responceError = error as? ResponseError {
@@ -137,7 +137,7 @@ class DetailViewModel {
                         }
                     }
                     else {
-                        print("不明なエラー\(error)")
+                        print("Other Error: \(error)")
                     }
                 })
                 .disposed(by: disposeBag)

--- a/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
+++ b/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
@@ -59,16 +59,23 @@ class DetailViewController: UIViewController {
             viewModel.todayDateDriver.drive(dateLabel.rx.text),
             viewModel.isLoadingDriver.drive(loadingView.indicator.rx.isAnimating),
             viewModel.isLoadingDriver.map { !($0) }.drive(loadingView.rx.isHidden),
-            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled),
-            viewModel.APIErrorMessageDriver.drive(onNext: { message in
-                let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in
-                    self.dismiss(animated: true)
-                }))
-                self.present(alert, animated: true, completion: nil)
-            })
+            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled)
         )
         displayChart()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel?.APIErrorMessageDriver.filter({ message in
+            message != ""
+        }).drive(onNext: { message in
+            let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in
+                self.dismiss(animated: true)
+            }))
+            self.present(alert, animated: true, completion: nil)
+        })
+        .disposed(by: disposeBag)
     }
     
     private func displayChart() {

--- a/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
+++ b/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
@@ -59,7 +59,19 @@ class DetailViewController: UIViewController {
             viewModel.todayDateDriver.drive(dateLabel.rx.text),
             viewModel.isLoadingDriver.drive(loadingView.indicator.rx.isAnimating),
             viewModel.isLoadingDriver.map { !($0) }.drive(loadingView.rx.isHidden),
-            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled)
+            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled),
+            viewModel.isLoading
+                .bind(to: loadingView.indicator.rx.isAnimating),
+            viewModel.isLoading
+                        .map { !($0) }
+                        .bind(to: loadingView.rx.isHidden),
+            viewModel.APIErrorMessageDriver.drive(onNext: { message in
+                let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in
+                    self.dismiss(animated: true)
+                }))
+                self.present(alert, animated: true, completion: nil)
+            })
         )
         displayChart()
     }

--- a/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
+++ b/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
@@ -70,8 +70,8 @@ class DetailViewController: UIViewController {
         displayChart()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         viewModel?.fetch()
     }
     

--- a/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
+++ b/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
@@ -51,31 +51,28 @@ class DetailViewController: UIViewController {
             closeButton.rx.tap.subscribe { _ in
                 self.dismiss(animated: true)
             },
-            Observable.just(()).bind(to: viewModel.fetchDataTrigger),
-            viewModel.weatherDataDriver.drive(detailTableView.rx.items(dataSource: dataSource)),
-            viewModel.selectedPrefecture.bind(to: prefectureLabel.rx.text),
-            viewModel.chartDataDriver.drive(popChartView.rx.chartData),
-            viewModel.chartFormatterDriver.drive(popChartView.xAxis.rx.valueFormatter),
-            viewModel.todayDateDriver.drive(dateLabel.rx.text),
+            viewModel.weatherData.asDriver(onErrorJustReturn: []).drive(detailTableView.rx.items(dataSource: dataSource)),
+            viewModel.selectedPrefecture.asDriver(onErrorJustReturn: "エラー").drive(prefectureLabel.rx.text),
+            viewModel.chartData.asDriver(onErrorJustReturn: LineChartData()).drive(popChartView.rx.chartData),
+            viewModel.chartFormatter.asDriver(onErrorJustReturn: IndexAxisValueFormatter()).drive(popChartView.xAxis.rx.valueFormatter),
+            viewModel.todayDate.asDriver(onErrorJustReturn: "").drive(dateLabel.rx.text),
             viewModel.isLoadingDriver.drive(loadingView.indicator.rx.isAnimating),
             viewModel.isLoadingDriver.map { !($0) }.drive(loadingView.rx.isHidden),
-            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled)
+            viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled),
+            viewModel.APIErrorMessage.asDriver(onErrorJustReturn: "").drive(onNext: { message in
+                let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in
+                    self.dismiss(animated: true)
+                }))
+                self.present(alert, animated: true, completion: nil)
+            })
         )
         displayChart()
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        viewModel?.APIErrorMessageDriver.filter({ message in
-            message != ""
-        }).drive(onNext: { message in
-            let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in
-                self.dismiss(animated: true)
-            }))
-            self.present(alert, animated: true, completion: nil)
-        })
-        .disposed(by: disposeBag)
+        viewModel?.fetch()
     }
     
     private func displayChart() {

--- a/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
+++ b/WeatherApp-MVVM/Views/Detail/DetailViewController.swift
@@ -60,11 +60,6 @@ class DetailViewController: UIViewController {
             viewModel.isLoadingDriver.drive(loadingView.indicator.rx.isAnimating),
             viewModel.isLoadingDriver.map { !($0) }.drive(loadingView.rx.isHidden),
             viewModel.isLoadingDriver.map { !($0) }.drive(view.rx.isUserInteractionEnabled),
-            viewModel.isLoading
-                .bind(to: loadingView.indicator.rx.isAnimating),
-            viewModel.isLoading
-                        .map { !($0) }
-                        .bind(to: loadingView.rx.isHidden),
             viewModel.APIErrorMessageDriver.drive(onNext: { message in
                 let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "閉じる", style: .default, handler: { _ in


### PR DESCRIPTION
【やったこと】
・エラーハンドリング
1,ネットワーク接続不可
2,タイムアウト(8秒で設定)
3,ステータスコードが400,500番台
4,デコードエラー
をダイアログでエラー表示
その他はコンソールに表示
・IconData取得失敗時に空のDataを渡す
天気情報を取得できたが、もし天気のアイコンデータを取得できなかった場合は空のDataを渡して何も表示されないようにした
・APICallerのsetupRequest関数をジェネリクスにして、リクエスト作成時にスタブと差し替えられるように修正
